### PR TITLE
Lite input number field alignment

### DIFF
--- a/src/LiteCreditCardInput.js
+++ b/src/LiteCreditCardInput.js
@@ -46,7 +46,6 @@ const s = StyleSheet.create({
   },
   numberInput: {
     width: INFINITE_WIDTH,
-    marginLeft: 20,
   },
   expiryInput: {
     width: 80,


### PR DESCRIPTION
The number field for the lite credit card input had a margin left of 20, which seems to be the standard separator margin between fields. Since this field will always be first, it does not really need it and would make more sense if it were aligned with the edge of the container. (Thoughts?)