### PR TITLE
Prop to allow dynamic disable/enable of autofocus

### DIFF
--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -60,6 +60,7 @@ export default class CreditCardInput extends Component {
     cardBrandIcons: PropTypes.object,
 
     allowScroll: PropTypes.bool,
+    disableAutoFocus: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -86,12 +87,15 @@ export default class CreditCardInput extends Component {
     invalidColor: "red",
     placeholderColor: "gray",
     allowScroll: false,
+    disableAutoFocus: false,
   };
 
-  componentDidMount = () => this._focus(this.props.focused);
+  componentDidMount = () => {
+    if (!this.props.disableAutoFocus) this._focus(this.props.focused);
+  }
 
   componentWillReceiveProps = newProps => {
-    if (this.props.focused !== newProps.focused) this._focus(newProps.focused);
+    if (!this.props.disableAutoFocus && this.props.focused !== newProps.focused) this._focus(newProps.focused);
   };
 
   _focus = field => {

--- a/src/LiteCreditCardInput.js
+++ b/src/LiteCreditCardInput.js
@@ -76,6 +76,8 @@ export default class LiteCreditCardInput extends Component {
     validColor: PropTypes.string,
     invalidColor: PropTypes.string,
     placeholderColor: PropTypes.string,
+
+    disableAutoFocus: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -87,13 +89,16 @@ export default class LiteCreditCardInput extends Component {
     validColor: "",
     invalidColor: "red",
     placeholderColor: "gray",
+    disableAutoFocus: false,
   };
 
-  componentDidMount = () => this._focus(this.props.focused);
+  componentDidMount = () => {
+    if (!this.props.disableAutoFocus) this._focus(this.props.focused);
+  }
 
   componentWillReceiveProps = newProps => {
-    if (this.props.focused !== newProps.focused) this._focus(newProps.focused);
-  };
+    if (!this.props.disableAutoFocus && this.props.focused !== newProps.focused) this._focus(newProps.focused);
+  }
 
   _focusNumber = () => this._focus("number");
   _focusExpiry = () => this._focus("expiry");


### PR DESCRIPTION
Added the `disableAutoFocus` prop to allow the focus/scrolling action of the form to be disabled. This is useful when the credit card input is used as part of a larger form, as it will steal focus when the form is loaded and information is filled in (e.g. editing previously entered data). Once the form is loaded, the autofocus can easily be enabled so that the input will behave normally when the user interacts with it.