### PR TITLE
Pass other input properties to each input

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@ _onChange => form => console.log(form);
 |validColor | PropTypes.string | Color that will be applied for valid text input. Defaults to: "{inputStyle.color}" |
 |invalidColor | PropTypes.string | Color that will be applied for invalid text input. Defaults to: "red" |
 |placeholderColor | PropTypes.string | Color that will be applied for text input placeholder. Defaults to: "gray" |
+| additionalInputsProps | PropTypes.objectOf(TextInput.propTypes) | An object with Each key of the object corresponding to the name of the field. Allows you to change all props documented in [RN TextInput](https://facebook.github.io/react-native/docs/textinput.html).
 
 #### NOTES
 LiteCreditCardInput does not support `requiresName`, `requiresCVC`, and `requiresPostalCode` at the moment, PRs are welcome :party:
@@ -118,6 +119,7 @@ LiteCreditCardInput does not support `requiresName`, `requiresCVC`, and `require
 |validatePostalCode | PropTypes.func | Function to validate postalCode, expects `incomplete`, `valid`, or `invalid` as return values|
 |allowScroll | PropTypes.bool | enables horizontal scrolling on CreditCardInput <br/> Defaults to `false` |
 |cardBrandIcons | PropTypes.object | brand icons for CardView. see `./src/Icons.js` for details |
+| additionalInputsProps | PropTypes.objectOf(TextInput.propTypes) | An object with Each key of the object corresponding to the name of the field. Allows you to change all props documented in [RN TextInput](https://facebook.github.io/react-native/docs/textinput.html).
 
 ##CardView
 
@@ -135,6 +137,23 @@ LiteCreditCardInput does not support `requiresName`, `requiresCVC`, and `require
 |imageFront | PropTypes.number | Image for the credit-card |
 |imageBack | PropTypes.number | Image for the credit-card |
 |customIcons | PropTypes.object | brand icons for CardView. see `./src/Icons.js` for details |
+
+#### Note on additionalInputsProps
+
+additionalInputsProps gives you more control over the inputs in LiteCreditCardInput and CreditCardInput. An example object is as follows:
+```javascript
+addtionalInputProps = {
+  name: {
+    defaultValue: 'my name',
+    maxLength: 40,
+  },
+  postalCode: {
+    returnKeyType: 'go',
+  },
+};
+```
+
+The above would set the default value of the name field to `my name` and limit the input to a maximum of 40 character. In addition, it would set the returnKeyType of the postalcode field to `go`.
 
 # Methods
 ## setValues

--- a/src/CCInput.js
+++ b/src/CCInput.js
@@ -34,6 +34,7 @@ export default class CCInput extends Component {
     onChange: PropTypes.func,
     onBecomeEmpty: PropTypes.func,
     onBecomeValid: PropTypes.func,
+    additionalInputProps: PropTypes.shape(TextInput.propTypes),
   };
 
   static defaultProps = {
@@ -48,6 +49,7 @@ export default class CCInput extends Component {
     onChange: () => {},
     onBecomeEmpty: () => {},
     onBecomeValid: () => {},
+    additionalInputProps: {},
   };
 
   componentWillReceiveProps = newProps => {
@@ -66,13 +68,15 @@ export default class CCInput extends Component {
   render() {
     const { label, value, placeholder, status, keyboardType,
             containerStyle, inputStyle, labelStyle,
-            validColor, invalidColor, placeholderColor } = this.props;
+            validColor, invalidColor, placeholderColor,
+            additionalInputProps } = this.props;
     return (
       <TouchableOpacity onPress={this.focus}
           activeOpacity={0.99}>
         <View style={[containerStyle]}>
           { !!label && <Text style={[labelStyle]}>{label}</Text>}
           <TextInput ref="input"
+              {...additionalInputProps}
               keyboardType={keyboardType}
               autoCapitalise="words"
               autoCorrect={false}

--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -6,6 +6,7 @@ import ReactNative, {
   StyleSheet,
   ScrollView,
   Dimensions,
+  TextInput,
 } from "react-native";
 
 import CreditCard from "./CardView";
@@ -60,6 +61,8 @@ export default class CreditCardInput extends Component {
     cardBrandIcons: PropTypes.object,
 
     allowScroll: PropTypes.bool,
+
+    additionalInputsProps: PropTypes.objectOf(PropTypes.shape(TextInput.propTypes)),
   };
 
   static defaultProps = {
@@ -86,6 +89,7 @@ export default class CreditCardInput extends Component {
     invalidColor: "red",
     placeholderColor: "gray",
     allowScroll: false,
+    additionalInputsProps: {},
   };
 
   componentDidMount = () => this._focus(this.props.focused);
@@ -113,6 +117,7 @@ export default class CreditCardInput extends Component {
       inputStyle, labelStyle, validColor, invalidColor, placeholderColor,
       placeholders, labels, values, status,
       onFocus, onChange, onBecomeEmpty, onBecomeValid,
+      additionalInputsProps,
     } = this.props;
 
     return {
@@ -127,6 +132,8 @@ export default class CreditCardInput extends Component {
       status: status[field],
 
       onFocus, onChange, onBecomeEmpty, onBecomeValid,
+
+      additionalInputProps: additionalInputsProps[field],
     };
   };
 

--- a/src/LiteCreditCardInput.js
+++ b/src/LiteCreditCardInput.js
@@ -6,6 +6,7 @@ import {
   Image,
   LayoutAnimation,
   TouchableOpacity,
+  TextInput,
 } from "react-native";
 
 import Icons from "./Icons";
@@ -76,6 +77,8 @@ export default class LiteCreditCardInput extends Component {
     validColor: PropTypes.string,
     invalidColor: PropTypes.string,
     placeholderColor: PropTypes.string,
+
+    additionalInputsProps: PropTypes.objectOf(PropTypes.shape(TextInput.propTypes)),
   };
 
   static defaultProps = {
@@ -87,6 +90,7 @@ export default class LiteCreditCardInput extends Component {
     validColor: "",
     invalidColor: "red",
     placeholderColor: "gray",
+    additionalInputsProps: {},
   };
 
   componentDidMount = () => this._focus(this.props.focused);
@@ -109,6 +113,7 @@ export default class LiteCreditCardInput extends Component {
       inputStyle, validColor, invalidColor, placeholderColor,
       placeholders, values, status,
       onFocus, onChange, onBecomeEmpty, onBecomeValid,
+      additionalInputsProps,
     } = this.props;
 
     return {
@@ -121,6 +126,7 @@ export default class LiteCreditCardInput extends Component {
       status: status[field],
 
       onFocus, onChange, onBecomeEmpty, onBecomeValid,
+      additionalInputProps: additionalInputsProps[field],
     };
   };
 


### PR DESCRIPTION
I wanted a way to pass additional input props to my inputs. For example, what if you want the returnKeyType to be different than the default.

additionalInputProps is an object that has keys that correspond to the names of each field. You can pass down any props as documented in the RN docs. Let me know if you need anything else for this PR.