### PR TITLE
create style override props, update props in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,12 +67,12 @@ _onChange => form => console.log(form);
 	number: "incomplete",
 	expiry: "incomplete",
 	cvc: "incomplete",
-	name: "incomplete", 
+	name: "incomplete",
 	postalCode: "incomplete",
   },
 };
 
-// Notes: 
+// Notes:
 // cvc, name, & postalCode will only be available when the respective props is enabled (e.g. requiresName, requiresCVC)
 ```
 
@@ -85,7 +85,12 @@ _onChange => form => console.log(form);
 |onChange | PropTypes.func | Receives a `formData` object every time the form changes |
 |onFocus | PropTypes.func | Receives the name of currently focused field |
 |placeholders | PropTypes.object | Defaults to <br/>`{ number: "1234 5678 1234 5678", expiry: "MM/YY", cvc: "CVC" }` |
+|containerStyle | View.propTypes.style | Style for wrapping view<br/> Defaults to: `{ paddingHorizontal: 10, flexDirection: "row", alignItems: "center", overflow: "hidden" }` |
 |inputStyle | Text.propTypes.style | Style for credit-card form's textInput |
+|numberInputContainerStyle | View.propTypes.style | Style for card number's textInput container<br/> Defaults to: `{ width: 1000 }` |
+|expiryInputContainerStyle | View.propTypes.style | Style for expiry's textInput container<br/> Defaults to: `{ width: 80 }` |
+|cvcInputContainerStyle | View.propTypes.style | Style for cvc's textInput container<br/> Defaults to: `{ width: 80 }` |
+|lastFourInputContainerStyle | View.propTypes.style | Style for last 4 digits textInput container<br/> Defaults to: `{ width: 60, marginLeft: 20 }` |
 |validColor | PropTypes.string | Color that will be applied for valid text input. Defaults to: "{inputStyle.color}" |
 |invalidColor | PropTypes.string | Color that will be applied for invalid text input. Defaults to: "red" |
 |placeholderColor | PropTypes.string | Color that will be applied for text input placeholder. Defaults to: "gray" |
@@ -110,6 +115,11 @@ LiteCreditCardInput does not support `requiresName`, `requiresCVC`, and `require
 |labelStyle | Text.propTypes.style | Style for credit-card form's labels |
 |inputStyle | Text.propTypes.style | Style for credit-card form's textInput |
 |inputContainerStyle | View.propTypes.style | Style for textInput's container<br/> Defaults to: `{ borderBottomWidth: 1, borderBottomColor: "black" }` |
+|numberInputContainerStyle | View.propTypes.style | Style for card number's textInput container<br/> Defaults to: `{ width: Dimensions.get("window").width - 110 }` |
+|expiryInputContainerStyle | View.propTypes.style | Style for expiry's textInput container<br/> Defaults to: `{ width: 40 }` |
+|cvcInputContainerStyle | View.propTypes.style | Style for cvc's textInput container<br/> Defaults to: `{ width: 70 }` |
+|nameInputContainerStyle | View.propTypes.style | Style for name's textInput container<br/> Defaults to: `{ width: Dimensions.get("window").width - 110 }` |
+|postalCodeInputContainerStyle | View.propTypes.style | Style for postal code's textInput container<br/> Defaults to: `{ width: 120 }` |
 |validColor | PropTypes.string | Color that will be applied for valid text input. Defaults to: "{inputStyle.color}" |
 |invalidColor | PropTypes.string | Color that will be applied for invalid text input. Defaults to: "red" |
 |placeholderColor | PropTypes.string | Color that will be applied for text input placeholder. Defaults to: "gray" |

--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -49,6 +49,11 @@ export default class CreditCardInput extends Component {
     labelStyle: Text.propTypes.style,
     inputStyle: Text.propTypes.style,
     inputContainerStyle: View.propTypes.style,
+    numberInputContainerStyle: View.propTypes.style,
+    expiryInputContainerStyle: View.propTypes.style,
+    cvcInputContainerStyle: View.propTypes.style,
+    nameInputContainerStyle: View.propTypes.style,
+    postalCodeInputContainerStyle: View.propTypes.style,
 
     validColor: PropTypes.string,
     invalidColor: PropTypes.string,
@@ -85,6 +90,12 @@ export default class CreditCardInput extends Component {
       borderBottomWidth: 1,
       borderBottomColor: "black",
     },
+    numberInputContainerStyle: { width: CARD_NUMBER_INPUT_WIDTH },
+    expiryInputContainerStyle: { width: EXPIRY_INPUT_WIDTH },
+    cvcInputContainerStyle: { width: CVC_INPUT_WIDTH },
+    nameInputContainerStyle: { width: NAME_INPUT_WIDTH },
+    postalCodeInputContainerStyle: { width: POSTAL_CODE_INPUT_WIDTH },
+
     validColor: "",
     invalidColor: "red",
     placeholderColor: "gray",
@@ -165,19 +176,19 @@ export default class CreditCardInput extends Component {
             showsHorizontalScrollIndicator={false}
             style={s.form}>
           <CCInput {...this._inputProps("number")}
-              containerStyle={[s.inputContainer, inputContainerStyle, { width: CARD_NUMBER_INPUT_WIDTH }]} />
+              containerStyle={[s.inputContainer, inputContainerStyle, this.props.numberInputContainerStyle]} />
           <CCInput {...this._inputProps("expiry")}
-              containerStyle={[s.inputContainer, inputContainerStyle, { width: EXPIRY_INPUT_WIDTH }]} />
+              containerStyle={[s.inputContainer, inputContainerStyle, this.props.expiryInputContainerStyle]} />
           { requiresCVC &&
             <CCInput {...this._inputProps("cvc")}
-                containerStyle={[s.inputContainer, inputContainerStyle, { width: CVC_INPUT_WIDTH }]} /> }
+                containerStyle={[s.inputContainer, inputContainerStyle, this.props.cvcInputContainerStyle]} /> }
           { requiresName &&
             <CCInput {...this._inputProps("name")}
                 keyboardType="default"
-                containerStyle={[s.inputContainer, inputContainerStyle, { width: NAME_INPUT_WIDTH }]} /> }
+                containerStyle={[s.inputContainer, inputContainerStyle, this.props.nameInputContainerStyle]} /> }
           { requiresPostalCode &&
             <CCInput {...this._inputProps("postalCode")}
-                containerStyle={[s.inputContainer, inputContainerStyle, { width: POSTAL_CODE_INPUT_WIDTH }]} /> }
+                containerStyle={[s.inputContainer, inputContainerStyle, this.props.postalCodeInputContainerStyle]} /> }
         </ScrollView>
       </View>
     );

--- a/src/LiteCreditCardInput.js
+++ b/src/LiteCreditCardInput.js
@@ -17,8 +17,7 @@ const INFINITE_WIDTH = 1000;
 
 const s = StyleSheet.create({
   container: {
-    paddingLeft: 10,
-    paddingRight: 10,
+    paddingHorizontal: 10,
     flexDirection: "row",
     alignItems: "center",
     overflow: "hidden",
@@ -72,6 +71,11 @@ export default class LiteCreditCardInput extends Component {
     placeholders: PropTypes.object,
 
     inputStyle: Text.propTypes.style,
+    containerStyle: View.propTypes.style,
+    numberInputContainerStyle: View.propTypes.style,
+    expiryInputContainerStyle: View.propTypes.style,
+    cvcInputContainerStyle: View.propTypes.style,
+    lastFourInputContainerStyle: View.propTypes.style,
 
     validColor: PropTypes.string,
     invalidColor: PropTypes.string,
@@ -142,13 +146,13 @@ export default class LiteCreditCardInput extends Component {
     const showRightPart = focused && focused !== "number";
 
     return (
-      <View style={s.container}>
+      <View style={[s.container, this.props.containerStyle]}>
         <View style={[
           s.leftPart,
           showRightPart ? s.hidden : s.expanded,
         ]}>
           <CCInput {...this._inputProps("number")}
-              containerStyle={s.numberInput} />
+              containerStyle={[s.numberInput, this.props.numberInputContainerStyle]} />
         </View>
         <TouchableOpacity onPress={showRightPart ? this._focusNumber : this._focusExpiry }>
           <Image style={s.icon}
@@ -164,13 +168,13 @@ export default class LiteCreditCardInput extends Component {
               <CCInput field="last4"
                   value={ numberStatus === "valid" ? number.substr(number.length - 4, 4) : "" }
                   inputStyle={[s.input, inputStyle]}
-                  containerStyle={[s.last4Input]} />
+                  containerStyle={[s.last4Input, this.props.lastFourInputContainerStyle]} />
             </View>
           </TouchableOpacity>
           <CCInput {...this._inputProps("expiry")}
-              containerStyle={s.expiryInput} />
+              containerStyle={[s.expiryInput, this.props.expiryInputContainerStyle]} />
           <CCInput {...this._inputProps("cvc")}
-              containerStyle={s.cvcInput} />
+              containerStyle={[s.cvcInput, this.props.cvcInputContainerStyle]} />
         </View>
       </View>
     );


### PR DESCRIPTION
I would like to be able to override the styles of internal components.  

I've added a few style override props to both `CreditCardInput` and `LiteCreditCardInput`, and subsequently updated the README with the new props and their corresponding annotations.

These props were originally called for in this closed issue https://github.com/sbycrosz/react-native-credit-card-input/issues/12
