### PR TITLE
Fix autoCapitalize on Android due to a bug in react native

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/sbycrosz/react-native-credit-card-input#readme",
   "dependencies": {
     "card-validator": "^3.0.0",
-    "react-native-flip-card": "^3.3.0",
+    "react-native-flip-card": "adahealth/react-native-flip-card#dddd0c103240f3cebda036729d37f5532dcc71fb",
     "lodash.compact": "^3.0.1",
     "lodash.every": "^4.6.0",
     "lodash.pick": "^4.4.0",

--- a/src/CCInput.js
+++ b/src/CCInput.js
@@ -41,7 +41,6 @@ export default class CCInput extends Component {
     label: "",
     value: "",
     status: "incomplete",
-    keyboardType: "numeric",
     containerStyle: {},
     inputStyle: {},
     labelStyle: {},

--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -165,18 +165,21 @@ export default class CreditCardInput extends Component {
             showsHorizontalScrollIndicator={false}
             style={s.form}>
           <CCInput {...this._inputProps("number")}
+              keyboardType="numeric"
               containerStyle={[s.inputContainer, inputContainerStyle, { width: CARD_NUMBER_INPUT_WIDTH }]} />
           <CCInput {...this._inputProps("expiry")}
+              keyboardType="numeric"
               containerStyle={[s.inputContainer, inputContainerStyle, { width: EXPIRY_INPUT_WIDTH }]} />
           { requiresCVC &&
             <CCInput {...this._inputProps("cvc")}
+                keyboardType="numeric"
                 containerStyle={[s.inputContainer, inputContainerStyle, { width: CVC_INPUT_WIDTH }]} /> }
           { requiresName &&
             <CCInput {...this._inputProps("name")}
-                keyboardType="default"
                 containerStyle={[s.inputContainer, inputContainerStyle, { width: NAME_INPUT_WIDTH }]} /> }
           { requiresPostalCode &&
             <CCInput {...this._inputProps("postalCode")}
+                keyboardType="numeric"
                 containerStyle={[s.inputContainer, inputContainerStyle, { width: POSTAL_CODE_INPUT_WIDTH }]} /> }
         </ScrollView>
       </View>

--- a/src/LiteCreditCardInput.js
+++ b/src/LiteCreditCardInput.js
@@ -148,6 +148,7 @@ export default class LiteCreditCardInput extends Component {
           showRightPart ? s.hidden : s.expanded,
         ]}>
           <CCInput {...this._inputProps("number")}
+              keyboardType="numeric"
               containerStyle={s.numberInput} />
         </View>
         <TouchableOpacity onPress={showRightPart ? this._focusNumber : this._focusExpiry }>
@@ -168,8 +169,10 @@ export default class LiteCreditCardInput extends Component {
             </View>
           </TouchableOpacity>
           <CCInput {...this._inputProps("expiry")}
+              keyboardType="numeric"
               containerStyle={s.expiryInput} />
           <CCInput {...this._inputProps("cvc")}
+              keyboardType="numeric"
               containerStyle={s.cvcInput} />
         </View>
       </View>


### PR DESCRIPTION
Autocapitalize on name field doesn't work on Android depending on the properties passed to TextInput. The workaround is to omit keyboardType='default' on this field by explicitly setting keyboardType='numeric' on the other fields. 

This bug is described in detail here:
https://github.com/facebook/react-native/issues/11776

Also, this PR fixes https://github.com/sbycrosz/react-native-credit-card-input/issues/50, in which the back of the card is mirrored, by referencing a specific commit of the 'react-native-flip-card' dependency. This is important for this component to work nicely on RN 0.42.