### PR TITLE
Allow additionalInputProps to override default TextInput props

### DIFF
--- a/src/CCInput.js
+++ b/src/CCInput.js
@@ -76,7 +76,6 @@ export default class CCInput extends Component {
         <View style={[containerStyle]}>
           { !!label && <Text style={[labelStyle]}>{label}</Text>}
           <TextInput ref="input"
-              {...additionalInputProps}
               keyboardType={keyboardType}
               autoCapitalise="words"
               autoCorrect={false}
@@ -92,7 +91,8 @@ export default class CCInput extends Component {
               placeholder={placeholder}
               value={value}
               onFocus={this._onFocus}
-              onChangeText={this._onChange} />
+              onChangeText={this._onChange}
+              {...additionalInputProps} />
         </View>
       </TouchableOpacity>
     );


### PR DESCRIPTION
Allows a bit more customization, let me know what you think @sbycrosz.

(recreated pr https://github.com/sbycrosz/react-native-credit-card-input/pull/46 on a branch)