### PR TITLE
Fix React PropTypes deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "lodash.compact": "^3.0.1",
     "lodash.every": "^4.6.0",
     "lodash.pick": "^4.4.0",
-    "lodash.values": "^4.3.0"
+    "lodash.values": "^4.3.0",
+    "prop-types": "^15.5.10"
   },
   "devDependencies": {
     "babel-eslint": "^5.0.0",

--- a/src/CCInput.js
+++ b/src/CCInput.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import {
   View,
   Text,

--- a/src/CardView.js
+++ b/src/CardView.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import {
   View,
   Image,

--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import ReactNative, {
   NativeModules,
   View,

--- a/src/LiteCreditCardInput.js
+++ b/src/LiteCreditCardInput.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import {
   View,
   Text,

--- a/src/connectToState.js
+++ b/src/connectToState.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import CCFieldFormatter from "./CCFieldFormatter";
 import CCFieldValidator from "./CCFieldValidator";
 import compact from "lodash.compact";


### PR DESCRIPTION
Now depends on "prop-types" module.
Sending a PR to "react-native-flip-card" as well.