### PR TITLE
Make ViewPropTypes backwards compatible

### DIFF
--- a/src/CCInput.js
+++ b/src/CCInput.js
@@ -9,6 +9,8 @@ import {
   ViewPropTypes,
 } from "react-native";
 
+const viewPropTypes = ViewPropTypes || View.propTypes;
+
 const s = StyleSheet.create({
   baseInputStyle: {
     color: "black",
@@ -25,7 +27,7 @@ export default class CCInput extends Component {
 
     status: PropTypes.oneOf(["valid", "invalid", "incomplete"]),
 
-    containerStyle: ViewPropTypes.style,
+    containerStyle: viewPropTypes.style,
     inputStyle: Text.propTypes.style,
     labelStyle: Text.propTypes.style,
     validColor: PropTypes.string,

--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -15,6 +15,8 @@ import CreditCard from "./CardView";
 import CCInput from "./CCInput";
 import { InjectedProps } from "./connectToState";
 
+const viewPropTypes = ViewPropTypes || View.propTypes;
+
 const s = StyleSheet.create({
   container: {
     alignItems: "center",
@@ -50,7 +52,7 @@ export default class CreditCardInput extends Component {
 
     labelStyle: Text.propTypes.style,
     inputStyle: Text.propTypes.style,
-    inputContainerStyle: ViewPropTypes.style,
+    inputContainerStyle: viewPropTypes.style,
 
     validColor: PropTypes.string,
     invalidColor: PropTypes.string,


### PR DESCRIPTION
This makes `ViewPropTypes` fail gracefully to `View.propTypes` for older versions of `react-native`