### PR TITLE
Fixed scaling issues for both Android and Ios fixes #95

### DIFF
--- a/src/CardView.js
+++ b/src/CardView.js
@@ -118,10 +118,11 @@ export default class CardView extends Component {
     const isAmex = brand === "american-express";
     const shouldFlip = !isAmex && focused === "cvc";
 
-    const containerSize = { ...BASE_SIZE, height: BASE_SIZE.height * scale };
+    const containerSize = { ...BASE_SIZE, width: BASE_SIZE.width * scale, height: BASE_SIZE.height * scale };
     const transform = { transform: [
-      { scale },
+      { translateX: ((BASE_SIZE.width * (scale - 1) / 2)) },
       { translateY: ((BASE_SIZE.height * (scale - 1) / 2)) },
+      { scale },
     ] };
 
     return (


### PR DESCRIPTION
The translation should be applied before scaling to avoid cropping in Android and incorrect positions in both Android and Ios.

The width needs to be scaled for scaling > 1

This fixes all issues with scaling issues

@sbycrosz
Thanks for a great component. Hope you will merge this, it's tested on both Ios and Android.