### PR TITLE
Ability to set initial values of form

### DIFF
--- a/src/connectToState.js
+++ b/src/connectToState.js
@@ -47,7 +47,7 @@ export default function connectToState(CreditCardInput) {
       super();
       this.state = {
         focused: "",
-        values: {},
+        values: this.props.values || {},
         status: {},
       };
     }


### PR DESCRIPTION
Useful for example if I want in __DEV__ to init the form to valid Stripe card infos, to simplify testing. If `setValues` exist, init with values should also be possible