### PR TITLE
remove <TouchableOpacity> wrapper

### DIFF
--- a/src/CCInput.js
+++ b/src/CCInput.js
@@ -72,30 +72,27 @@ export default class CCInput extends Component {
             validColor, invalidColor, placeholderColor,
             additionalInputProps } = this.props;
     return (
-      <TouchableOpacity onPress={this.focus}
-        activeOpacity={0.99}>
-        <View style={[containerStyle]}>
-          { !!label && <Text style={[labelStyle]}>{label}</Text>}
-          <TextInput ref="input"
-            {...additionalInputProps}
-            keyboardType={keyboardType}
-            autoCapitalise="words"
-            autoCorrect={false}
-            style={[
-              s.baseInputStyle,
-              inputStyle,
-              ((validColor && status === "valid") ? { color: validColor } :
-              (invalidColor && status === "invalid") ? { color: invalidColor } :
-              {}),
-            ]}
-            underlineColorAndroid={"transparent"}
-            placeholderTextColor={placeholderColor}
-            placeholder={placeholder}
-            value={value}
-            onFocus={this._onFocus}
-            onChangeText={this._onChange} />
-        </View>
-      </TouchableOpacity>
+      <View style={[containerStyle]}>
+        { !!label && <Text style={[labelStyle]}>{label}</Text>}
+        <TextInput ref="input"
+          {...additionalInputProps}
+          keyboardType={keyboardType}
+          autoCapitalise="words"
+          autoCorrect={false}
+          style={[
+            s.baseInputStyle,
+            inputStyle,
+            ((validColor && status === "valid") ? { color: validColor } :
+            (invalidColor && status === "invalid") ? { color: invalidColor } :
+            {}),
+          ]}
+          underlineColorAndroid={"transparent"}
+          placeholderTextColor={placeholderColor}
+          placeholder={placeholder}
+          value={value}
+          onFocus={this._onFocus}
+          onChangeText={this._onChange} />
+      </View>
     );
   }
 }

--- a/src/CardView.js
+++ b/src/CardView.js
@@ -118,10 +118,11 @@ export default class CardView extends Component {
     const isAmex = brand === "american-express";
     const shouldFlip = !isAmex && focused === "cvc";
 
-    const containerSize = { ...BASE_SIZE, height: BASE_SIZE.height * scale };
+    const containerSize = { ...BASE_SIZE, width: BASE_SIZE.width * scale, height: BASE_SIZE.height * scale };
     const transform = { transform: [
-      { scale },
+      { translateX: ((BASE_SIZE.width * (scale - 1) / 2)) },
       { translateY: ((BASE_SIZE.height * (scale - 1) / 2)) },
+      { scale },
     ] };
 
     return (

--- a/src/LiteCreditCardInput.js
+++ b/src/LiteCreditCardInput.js
@@ -23,11 +23,13 @@ const s = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     overflow: "hidden",
+    backgroundColor: "#ffffff",
   },
   icon: {
     width: 48,
     height: 40,
     resizeMode: "contain",
+    backgroundColor: "#ffffff",
   },
   expanded: {
     flex: 1,
@@ -41,6 +43,7 @@ const s = StyleSheet.create({
   rightPart: {
     overflow: "hidden",
     flexDirection: "row",
+    backgroundColor: "#ffffff"
   },
   last4: {
     flex: 1,


### PR DESCRIPTION
`<TouchableOpacity>` wrapping `<TextInput>` elements was causing those child elements to be unavailable to accessibility, and therefore unable to be used in UI tests.