### PR TITLE
Vertical form support with rows

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,23 +56,23 @@ _onChange => form => console.log(form);
 {
   valid: true, // will be true once all fields are "valid" (time to enable the submit button)
   values: { // will be in the sanitized and formatted form
-  	number: "4242 4242",
-  	expiry: "06/19",
-  	cvc: "300",
-  	type: "visa", // will be one of [null, "visa", "master-card", "american-express", "diners-club", "discover", "jcb", "unionpay", "maestro"]
-  	name: "Sam",
-  	postalCode: "34567",
+    number: "4242 4242",
+    expiry: "06/19",
+    cvc: "300",
+    type: "visa", // will be one of [null, "visa", "master-card", "american-express", "diners-club", "discover", "jcb", "unionpay", "maestro"]
+    name: "Sam",
+    postalCode: "34567",
   },
   status: {  // will be one of ["incomplete", "invalid", and "valid"]
-	number: "incomplete",
-	expiry: "incomplete",
-	cvc: "incomplete",
-	name: "incomplete", 
-	postalCode: "incomplete",
+  number: "incomplete",
+  expiry: "incomplete",
+  cvc: "incomplete",
+  name: "incomplete",
+  postalCode: "incomplete",
   },
 };
 
-// Notes: 
+// Notes:
 // cvc, name, & postalCode will only be available when the respective props is enabled (e.g. requiresName, requiresCVC)
 ```
 
@@ -107,6 +107,8 @@ LiteCreditCardInput does not support `requiresName`, `requiresCVC`, and `require
 |cardFontFamily | PropTypes.string | Font family for the CreditCardView, works best with monospace fonts. Defaults to Courier (iOS) or monospace (android) |
 |cardImageFront | PropTypes.number | Image for the credit-card view `e.g. require("./card.png")` |
 |cardImageBack | PropTypes.number | Image for the credit-card view `e.g. require("./card.png")` |
+|formStyle | ViewPropTypes.style | Style for credit-card form |
+|verticalFormRowStyle | ViewPropTypes.style | Style for the rows when using a vertical form |
 |labelStyle | Text.propTypes.style | Style for credit-card form's labels |
 |inputStyle | Text.propTypes.style | Style for credit-card form's textInput |
 |inputContainerStyle | ViewPropTypes.style | Style for textInput's container<br/> Defaults to: `{ borderBottomWidth: 1, borderBottomColor: "black" }` |
@@ -119,7 +121,9 @@ LiteCreditCardInput does not support `requiresName`, `requiresCVC`, and `require
 |validatePostalCode | PropTypes.func | Function to validate postalCode, expects `incomplete`, `valid`, or `invalid` as return values|
 |allowScroll | PropTypes.bool | enables horizontal scrolling on CreditCardInput <br/> Defaults to `false` |
 |cardBrandIcons | PropTypes.object | brand icons for CardView. see `./src/Icons.js` for details |
-| additionalInputsProps | PropTypes.objectOf(TextInput.propTypes) | An object with Each key of the object corresponding to the name of the field. Allows you to change all props documented in [RN TextInput](https://facebook.github.io/react-native/docs/textinput.html).
+| additionalInputsProps | PropTypes.objectOf(TextInput.propTypes) | An object with Each key of the object corresponding to the name of the field. Allows you to change all props documented in [RN TextInput](https://facebook.github.io/react-native/docs/textinput.html).|
+|verticalForm| PropTypes.bool | Enables vertical form instead of horizontal |
+|verticalFormRows| PropTypes.array | Array of rows with fields inse for the vertical form. Supported field parameters are `name` (number,expiry,cvc,number,postalCode) and `width`. Example: `[{ fields: [{ name: 'name' }] }, { fields: [{ name: 'number' }, { name: 'expiry' }] }]`.  |
 
 ##CardView
 
@@ -161,9 +165,9 @@ Set values into credit card form
 
 
 ```js
-	// sets 4242 on credit card number field
-	// other fields will stay unchanged
-	this.refs.CCInput.setValues({ number: "4242" });
+  // sets 4242 on credit card number field
+  // other fields will stay unchanged
+  this.refs.CCInput.setValues({ number: "4242" });
 ```
 
 **Known issues:** clearing a field e.g. `setValues({ expiry: "" })` will trigger the logic to `move to previous field` and trigger other kind of weird side effects. **PR plz**
@@ -173,8 +177,8 @@ Set values into credit card form
 focus on to specified field
 
 ```js
-	// focus to expiry field
-	this.refs.CCInput.focus("expiry");
+  // focus to expiry field
+  this.refs.CCInput.focus("expiry");
 ```
 
 # Example

--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -22,6 +22,14 @@ const s = StyleSheet.create({
   form: {
     marginTop: 20,
   },
+  verticalForm: {
+    marginTop: 20,
+  },
+  verticalFormRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
   inputContainer: {
     marginLeft: 20,
   },
@@ -48,6 +56,8 @@ export default class CreditCardInput extends Component {
     labels: PropTypes.object,
     placeholders: PropTypes.object,
 
+    formStyle: ViewPropTypes.style,
+    verticalFormRowStyle: ViewPropTypes.style,
     labelStyle: Text.propTypes.style,
     inputStyle: Text.propTypes.style,
     inputContainerStyle: ViewPropTypes.style,
@@ -65,6 +75,9 @@ export default class CreditCardInput extends Component {
     allowScroll: PropTypes.bool,
 
     additionalInputsProps: PropTypes.objectOf(PropTypes.shape(TextInput.propTypes)),
+
+    verticalForm: PropTypes.bool,
+    verticalFormRows: PropTypes.array,
   };
 
   static defaultProps = {
@@ -141,10 +154,9 @@ export default class CreditCardInput extends Component {
 
   render() {
     const {
-      cardImageFront, cardImageBack, inputContainerStyle,
-      values: { number, expiry, cvc, name, type }, focused,
-      allowScroll, requiresName, requiresCVC, requiresPostalCode,
-      cardScale, cardFontFamily, cardBrandIcons,
+      cardImageFront, cardImageBack, values: { number, expiry, cvc, name, type },
+      focused, requiresName, requiresCVC, requiresPostalCode, cardScale,
+      cardFontFamily, cardBrandIcons,
     } = this.props;
 
     return (
@@ -160,31 +172,93 @@ export default class CreditCardInput extends Component {
           number={number}
           expiry={expiry}
           cvc={cvc} />
-        <ScrollView ref="Form"
-          horizontal
-          keyboardShouldPersistTaps="always"
-          scrollEnabled={allowScroll}
-          showsHorizontalScrollIndicator={false}
-          style={s.form}>
-          <CCInput {...this._inputProps("number")}
-            keyboardType="numeric"
-            containerStyle={[s.inputContainer, inputContainerStyle, { width: CARD_NUMBER_INPUT_WIDTH }]} />
-          <CCInput {...this._inputProps("expiry")}
-            keyboardType="numeric"
-            containerStyle={[s.inputContainer, inputContainerStyle, { width: EXPIRY_INPUT_WIDTH }]} />
-          { requiresCVC &&
-            <CCInput {...this._inputProps("cvc")}
-              keyboardType="numeric"
-              containerStyle={[s.inputContainer, inputContainerStyle, { width: CVC_INPUT_WIDTH }]} /> }
-          { requiresName &&
-            <CCInput {...this._inputProps("name")}
-              containerStyle={[s.inputContainer, inputContainerStyle, { width: NAME_INPUT_WIDTH }]} /> }
-          { requiresPostalCode &&
-            <CCInput {...this._inputProps("postalCode")}
-              keyboardType="numeric"
-              containerStyle={[s.inputContainer, inputContainerStyle, { width: POSTAL_CODE_INPUT_WIDTH }]} /> }
-        </ScrollView>
+
+          { this.renderForm() }
       </View>
     );
+  }
+
+  renderForm = () => (
+    this.props.verticalForm ?
+      this.renderVerticalForm()
+      :
+      this.renderHorizontalForm()
+  )
+
+  renderHorizontalForm = () => {
+    const { formStyle, allowScroll, requiresName, requiresCVC, requiresPostalCode } = this.props;
+
+    return (
+      <ScrollView
+        ref="Form"
+        horizontal
+        keyboardShouldPersistTaps="always"
+        scrollEnabled={allowScroll}
+        showsHorizontalScrollIndicator={false}
+        style={[s.form, formStyle]}>
+        { this.renderField('number') }
+        { this.renderField('expiry') }
+        { requiresCVC && this.renderField('cvc') }
+        { requiresName && this.renderField('name') }
+        { requiresPostalCode && this.renderField('postalCode') }
+      </ScrollView>
+    );
+  }
+
+  renderVerticalForm = () => {
+    const { formStyle, verticalFormRowStyle, verticalFormRows } = this.props;
+
+    return (
+      <ScrollView
+        ref="Form"
+        keyboardShouldPersistTaps="always"
+        showsVerticalScrollIndicator={false}
+        style={[s.verticalForm, formStyle]}>
+        { verticalFormRows.map((row) => (
+          <View style={[s.verticalFormRow, verticalFormRowStyle]}>
+            { row.fields.map((field) => (
+              this.renderField(field.name, field.width)
+            ))}
+          </View>
+        ))}
+      </ScrollView>
+    )
+  }
+
+  renderField = (fieldName, fieldWidth) => {
+    const { inputContainerStyle } = this.props;
+
+    switch(fieldName) {
+      case 'number':
+        return <CCInput {...this._inputProps(fieldName)}
+          key={fieldName}
+          keyboardType="numeric"
+          containerStyle={[
+            s.inputContainer, inputContainerStyle,
+            { width: fieldWidth || CARD_NUMBER_INPUT_WIDTH }]} />;
+      case 'expiry':
+        return <CCInput {...this._inputProps(fieldName)}
+          key={fieldName}
+          keyboardType="numeric"
+          containerStyle={[
+            s.inputContainer,
+            inputContainerStyle, { width: fieldWidth || EXPIRY_INPUT_WIDTH }]} />
+      case 'cvc':
+        return <CCInput {...this._inputProps(fieldName)}
+          key={fieldName}
+          keyboardType="numeric"
+          containerStyle={[s.inputContainer, inputContainerStyle, { width: fieldWidth || CVC_INPUT_WIDTH }]} />;
+      case 'name':
+        return <CCInput {...this._inputProps(fieldName)}
+          key={fieldName}
+          containerStyle={[s.inputContainer, inputContainerStyle, { width: fieldWidth || NAME_INPUT_WIDTH }]} />;
+      case 'postalCode':
+        return <CCInput {...this._inputProps("postalCode")}
+          key={fieldName}
+          keyboardType="numeric"
+          containerStyle={[s.inputContainer, inputContainerStyle, { width: fieldWidth || POSTAL_CODE_INPUT_WIDTH }]} />;
+      default:
+        return null;
+    }
   }
 }

--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -214,7 +214,7 @@ export default class CreditCardInput extends Component {
         showsVerticalScrollIndicator={false}
         style={[s.verticalForm, formStyle]}>
         { verticalFormRows.map((row) => (
-          <View style={[s.verticalFormRow, verticalFormRowStyle]}>
+          <View style={[s.verticalFormRow, verticalFormRowStyle]} key={index}>
             { row.fields.map((field) => (
               this.renderField(field.name, field.width)
             ))}

--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -26,9 +26,9 @@ const s = StyleSheet.create({
     marginTop: 20,
   },
   verticalFormRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
   },
   inputContainer: {
     marginLeft: 20,
@@ -152,57 +152,51 @@ export default class CreditCardInput extends Component {
     };
   };
 
-  render() {
-    const {
-      cardImageFront, cardImageBack, values: { number, expiry, cvc, name, type },
-      focused, requiresName, requiresCVC, requiresPostalCode, cardScale,
-      cardFontFamily, cardBrandIcons,
-    } = this.props;
+  renderField = (fieldName, fieldWidth) => {
+    const { inputContainerStyle } = this.props;
 
-    return (
-      <View style={s.container}>
-        <CreditCard focused={focused}
-          brand={type}
-          scale={cardScale}
-          fontFamily={cardFontFamily}
-          imageFront={cardImageFront}
-          imageBack={cardImageBack}
-          customIcons={cardBrandIcons}
-          name={requiresName ? name : " "}
-          number={number}
-          expiry={expiry}
-          cvc={cvc} />
-
-          { this.renderForm() }
-      </View>
-    );
-  }
-
-  renderForm = () => (
-    this.props.verticalForm ?
-      this.renderVerticalForm()
-      :
-      this.renderHorizontalForm()
-  )
-
-  renderHorizontalForm = () => {
-    const { formStyle, allowScroll, requiresName, requiresCVC, requiresPostalCode } = this.props;
-
-    return (
-      <ScrollView
-        ref="Form"
-        horizontal
-        keyboardShouldPersistTaps="always"
-        scrollEnabled={allowScroll}
-        showsHorizontalScrollIndicator={false}
-        style={[s.form, formStyle]}>
-        { this.renderField('number') }
-        { this.renderField('expiry') }
-        { requiresCVC && this.renderField('cvc') }
-        { requiresName && this.renderField('name') }
-        { requiresPostalCode && this.renderField('postalCode') }
-      </ScrollView>
-    );
+    switch (fieldName) {
+      case "number":
+        return (
+          <CCInput {...this._inputProps(fieldName)}
+            key={fieldName}
+            keyboardType="numeric"
+            containerStyle={[
+              s.inputContainer, inputContainerStyle,
+              { width: fieldWidth || CARD_NUMBER_INPUT_WIDTH }]} />
+        );
+      case "expiry":
+        return (
+          <CCInput {...this._inputProps(fieldName)}
+            key={fieldName}
+            keyboardType="numeric"
+            containerStyle={[
+              s.inputContainer,
+              inputContainerStyle, { width: fieldWidth || EXPIRY_INPUT_WIDTH }]} />
+        );
+      case "cvc":
+        return (
+          <CCInput {...this._inputProps(fieldName)}
+            key={fieldName}
+            keyboardType="numeric"
+            containerStyle={[s.inputContainer, inputContainerStyle, { width: fieldWidth || CVC_INPUT_WIDTH }]} />
+        );
+      case "name":
+        return (
+          <CCInput {...this._inputProps(fieldName)}
+            key={fieldName}
+            containerStyle={[s.inputContainer, inputContainerStyle, { width: fieldWidth || NAME_INPUT_WIDTH }]} />
+        );
+      case "postalCode":
+        return (
+          <CCInput {...this._inputProps("postalCode")}
+            key={fieldName}
+            keyboardType="numeric"
+            containerStyle={[s.inputContainer, inputContainerStyle, { width: fieldWidth || POSTAL_CODE_INPUT_WIDTH }]} />
+        );
+      default:
+        return null;
+    }
   }
 
   renderVerticalForm = () => {
@@ -223,43 +217,58 @@ export default class CreditCardInput extends Component {
           </View>
         ))}
       </ScrollView>
-    )
+    );
   }
 
-  renderField = (fieldName, fieldWidth) => {
-    const { inputContainerStyle } = this.props;
+  renderHorizontalForm = () => {
+    const { formStyle, allowScroll, requiresName, requiresCVC, requiresPostalCode } = this.props;
 
-    switch(fieldName) {
-      case 'number':
-        return <CCInput {...this._inputProps(fieldName)}
-          key={fieldName}
-          keyboardType="numeric"
-          containerStyle={[
-            s.inputContainer, inputContainerStyle,
-            { width: fieldWidth || CARD_NUMBER_INPUT_WIDTH }]} />;
-      case 'expiry':
-        return <CCInput {...this._inputProps(fieldName)}
-          key={fieldName}
-          keyboardType="numeric"
-          containerStyle={[
-            s.inputContainer,
-            inputContainerStyle, { width: fieldWidth || EXPIRY_INPUT_WIDTH }]} />
-      case 'cvc':
-        return <CCInput {...this._inputProps(fieldName)}
-          key={fieldName}
-          keyboardType="numeric"
-          containerStyle={[s.inputContainer, inputContainerStyle, { width: fieldWidth || CVC_INPUT_WIDTH }]} />;
-      case 'name':
-        return <CCInput {...this._inputProps(fieldName)}
-          key={fieldName}
-          containerStyle={[s.inputContainer, inputContainerStyle, { width: fieldWidth || NAME_INPUT_WIDTH }]} />;
-      case 'postalCode':
-        return <CCInput {...this._inputProps("postalCode")}
-          key={fieldName}
-          keyboardType="numeric"
-          containerStyle={[s.inputContainer, inputContainerStyle, { width: fieldWidth || POSTAL_CODE_INPUT_WIDTH }]} />;
-      default:
-        return null;
-    }
+    return (
+      <ScrollView
+        ref="Form"
+        horizontal
+        keyboardShouldPersistTaps="always"
+        scrollEnabled={allowScroll}
+        showsHorizontalScrollIndicator={false}
+        style={[s.form, formStyle]}>
+        { this.renderField("number") }
+        { this.renderField("expiry") }
+        { requiresCVC && this.renderField("cvc") }
+        { requiresName && this.renderField("name") }
+        { requiresPostalCode && this.renderField("postalCode") }
+      </ScrollView>
+    );
+  }
+
+  renderForm = () => (
+    this.props.verticalForm ?
+      this.renderVerticalForm()
+      :
+      this.renderHorizontalForm()
+  )
+
+  render() {
+    const {
+      cardImageFront, cardImageBack, values: { number, expiry, cvc, name, type },
+      focused, requiresName, cardScale, cardFontFamily, cardBrandIcons,
+    } = this.props;
+
+    return (
+      <View style={s.container}>
+        <CreditCard focused={focused}
+          brand={type}
+          scale={cardScale}
+          fontFamily={cardFontFamily}
+          imageFront={cardImageFront}
+          imageBack={cardImageBack}
+          customIcons={cardBrandIcons}
+          name={requiresName ? name : " "}
+          number={number}
+          expiry={expiry}
+          cvc={cvc} />
+
+          { this.renderForm() }
+      </View>
+    );
   }
 }

--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -213,7 +213,7 @@ export default class CreditCardInput extends Component {
         keyboardShouldPersistTaps="always"
         showsVerticalScrollIndicator={false}
         style={[s.verticalForm, formStyle]}>
-        { verticalFormRows.map((row) => (
+        { verticalFormRows.map((row, index) => (
           <View style={[s.verticalFormRow, verticalFormRowStyle]} key={index}>
             { row.fields.map((field) => (
               this.renderField(field.name, field.width)

--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -211,6 +211,7 @@ export default class CreditCardInput extends Component {
     return (
       <ScrollView
         ref="Form"
+        horizontal={false}
         keyboardShouldPersistTaps="always"
         showsVerticalScrollIndicator={false}
         style={[s.verticalForm, formStyle]}>

--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -114,17 +114,21 @@ export default class CreditCardInput extends Component {
   };
 
   _focus = field => {
+    const { verticalForm } = this.props;
+
     if (!field) return;
 
     const scrollResponder = this.refs.Form.getScrollResponder();
     const nodeHandle = ReactNative.findNodeHandle(this.refs[field]);
 
-    NativeModules.UIManager.measureLayoutRelativeToParent(nodeHandle,
-      e => { throw e; },
-      x => {
-        scrollResponder.scrollTo({ x: Math.max(x - PREVIOUS_FIELD_OFFSET, 0), animated: true });
-        this.refs[field].focus();
-      });
+    if (!verticalForm) {
+      NativeModules.UIManager.measureLayoutRelativeToParent(nodeHandle,
+        e => { throw e; },
+        x => {
+          scrollResponder.scrollTo({ x: Math.max(x - PREVIOUS_FIELD_OFFSET, 0), animated: true });
+          this.refs[field].focus();
+        });
+    }
   }
 
   _inputProps = field => {


### PR DESCRIPTION
This PR adds support for a vertical form with rows that can be defined via props. Example:

```
<CreditCardInput
  onChange={this._onChange}
  requiresName
  requiresCVC
  verticalForm
  verticalFormRows={[
    { fields: [{ name: 'name' }] },
    { fields: [{ name: 'number' }] },
    { fields: [{ name: 'expiry' }, { name: 'cvc'}] }]} />
```

This will render a vertical form with 3 rows:

1. with the `name` input field
2. with the `number` input field
3. with the `expiry` and `cvc` fields in a horizontal row 