### PR TITLE
Fix react-native-web Compatibility for LiteCreditCardInput

### DIFF
--- a/src/CCInput.js
+++ b/src/CCInput.js
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   StyleSheet,
   ViewPropTypes,
+  Platform,
 } from "react-native";
 
 const s = StyleSheet.create({
@@ -71,6 +72,13 @@ export default class CCInput extends Component {
             containerStyle, inputStyle, labelStyle,
             validColor, invalidColor, placeholderColor,
             additionalInputProps } = this.props;
+
+    const webStyles = {}
+
+    if (Platform.OS === 'web') {
+      webStyles.outline = 'none'
+    }
+
     return (
       <TouchableOpacity onPress={this.focus}
         activeOpacity={0.99}>
@@ -78,12 +86,13 @@ export default class CCInput extends Component {
           { !!label && <Text style={[labelStyle]}>{label}</Text>}
           <TextInput ref="input"
             {...additionalInputProps}
-            keyboardType={keyboardType}
+            keyboardType={Platform.OS === 'web' ? undefined : keyboardType}
             autoCapitalise="words"
             autoCorrect={false}
             style={[
               s.baseInputStyle,
               inputStyle,
+              webStyles,
               ((validColor && status === "valid") ? { color: validColor } :
               (invalidColor && status === "invalid") ? { color: invalidColor } :
               {}),


### PR DESCRIPTION
## The Problem

Currently, `LiteCreditInput` is not working on the web (using [react-native-web](https://github.com/necolas/react-native-web)) because the inputs are number inputs, which on the web will not allow non-numeric characters (i.e. spaces, `/`, etc.). Additionally, focus outlines are making the display look different from on iOS / Android.

## Solution

This PR adds two fixes:

1. Changes the input type to `text` on web (by removing the `keyboardType` prop)
2. Removes the outline on web, in the styles
