### PR TITLE
additionalInputProps wasn't working properly

### DIFF
--- a/src/CCInput.js
+++ b/src/CCInput.js
@@ -88,7 +88,7 @@ export default class CCInput extends Component {
               ((validColor && status === "valid") ? { color: validColor } :
               (invalidColor && status === "invalid") ? { color: invalidColor } :
               {}),
-              ...additionalInputStyle
+              additionalInputStyle
             ]}
             underlineColorAndroid={"transparent"}
             placeholderTextColor={placeholderColor}

--- a/src/CCInput.js
+++ b/src/CCInput.js
@@ -70,14 +70,15 @@ export default class CCInput extends Component {
     const { label, value, placeholder, status, keyboardType,
             containerStyle, inputStyle, labelStyle,
             validColor, invalidColor, placeholderColor,
-            additionalInputProps } = this.props;
+            additionalInputProps: { 
+              style: additionalInputStyle = {}, ...additionalInputProps }
+            } = this.props;
     return (
       <TouchableOpacity onPress={this.focus}
         activeOpacity={0.99}>
         <View style={[containerStyle]}>
           { !!label && <Text style={[labelStyle]}>{label}</Text>}
           <TextInput ref="input"
-            {...additionalInputProps}
             keyboardType={keyboardType}
             autoCapitalise="words"
             autoCorrect={false}
@@ -87,13 +88,16 @@ export default class CCInput extends Component {
               ((validColor && status === "valid") ? { color: validColor } :
               (invalidColor && status === "invalid") ? { color: invalidColor } :
               {}),
+              ...additionalInputStyle
             ]}
             underlineColorAndroid={"transparent"}
             placeholderTextColor={placeholderColor}
             placeholder={placeholder}
             value={value}
             onFocus={this._onFocus}
-            onChangeText={this._onChange} />
+            onChangeText={this._onChange}
+            {...additionalInputProps}
+        />
         </View>
       </TouchableOpacity>
     );


### PR DESCRIPTION
The additionalInputProps prop was all but useless. Any passed in prop would be promptly overwritten by the defaults. The correct approach would be merging the added props at the end of the TextInput list of props, so that the props passed in will overwrite the defaults. The only problem would be extending the default styles. To do that, I've taken any style prop that comes down in the additionalInputProps and merged it at the end of the TextInput styles. I think this will do the trick.