### PR TITLE
fix(CCInput): correct autocapitalize typo

### DIFF
--- a/src/CCInput.js
+++ b/src/CCInput.js
@@ -79,7 +79,7 @@ export default class CCInput extends Component {
           <TextInput ref="input"
             {...additionalInputProps}
             keyboardType={keyboardType}
-            autoCapitalise="words"
+            autoCapitalize="words"
             autoCorrect={false}
             style={[
               s.baseInputStyle,


### PR DESCRIPTION
The autoCapitalize parameter for TextInput on CCInput was with a typo. 