### PR TITLE
Added a return key so the keyboard can be toggled on/off

### DIFF
--- a/src/CCInput.js
+++ b/src/CCInput.js
@@ -80,6 +80,7 @@ export default class CCInput extends Component {
             {...additionalInputProps}
             keyboardType={keyboardType}
             autoCapitalise="words"
+            returnKeyType='done'
             autoCorrect={false}
             style={[
               s.baseInputStyle,


### PR DESCRIPTION
Hey there! I've been having issues with the numeric keyboards using React 0.59+ where the numeric keypads in iOS cannot be retracted. I added a button which you may find useful. 