### PR TITLE
feat: add [autoComplete=cc-number|exp|csc] to inputfields

### DIFF
--- a/src/CreditCardInput.tsx
+++ b/src/CreditCardInput.tsx
@@ -111,6 +111,7 @@ const CreditCardInput = (props: Props) => {
         <TextInput
           ref={numberInput}
           keyboardType="numeric"
+          autoComplete="cc-number"
           style={[s.input, inputStyle]}
           placeholderTextColor={placeholderColor}
           placeholder={placeholders.number}
@@ -128,6 +129,7 @@ const CreditCardInput = (props: Props) => {
           <Text style={[s.inputLabel, labelStyle]}>{labels.expiry}</Text>
           <TextInput
             keyboardType="numeric"
+            autoComplete="cc-exp"
             style={[s.input, inputStyle]}
             placeholderTextColor={placeholderColor}
             placeholder={placeholders.expiry}
@@ -144,6 +146,7 @@ const CreditCardInput = (props: Props) => {
           <Text style={[s.inputLabel, labelStyle]}>{labels.cvc}</Text>
           <TextInput
             keyboardType="numeric"
+            autoComplete="cc-csc"
             style={[s.input, inputStyle]}
             placeholderTextColor={placeholderColor}
             placeholder={placeholders.cvc}

--- a/src/LiteCreditCardInput.tsx
+++ b/src/LiteCreditCardInput.tsx
@@ -144,6 +144,7 @@ const LiteCreditCardInput = (props: Props) => {
           <TextInput
             ref={numberInput}
             keyboardType="numeric"
+            autoComplete="cc-number"
             style={[s.input, inputStyle]}
             placeholderTextColor={placeholderColor}
             placeholder={placeholders.number}
@@ -191,6 +192,7 @@ const LiteCreditCardInput = (props: Props) => {
           <TextInput
             ref={expiryInput}
             keyboardType="numeric"
+            autoComplete="cc-exp"
             style={[s.input, inputStyle]}
             placeholderTextColor={placeholderColor}
             placeholder={placeholders.expiry}
@@ -207,6 +209,7 @@ const LiteCreditCardInput = (props: Props) => {
           <TextInput
             ref={cvcInput}
             keyboardType="numeric"
+            autoComplete="cc-csc"
             style={[s.input, inputStyle]}
             placeholderTextColor={placeholderColor}
             placeholder={placeholders.cvc}


### PR DESCRIPTION
Adds relevant autoComplete values to input fields.

This pull request improves the user experience and accessibility of the credit card input fields by adding appropriate `autoComplete` attributes to the relevant `TextInput` components in both `CreditCardInput` and `LiteCreditCardInput`. These changes help browsers and password managers recognize and autofill credit card information more reliably.

Enhancements to credit card input fields:

* Added `autoComplete="cc-number"` to the credit card number input fields in both `CreditCardInput` and `LiteCreditCardInput` components, enabling browsers to autofill the card number. [[1]](diffhunk://#diff-daf2f0bff42e60a4c77d7c68f4cce5cd347030af95752edc5dd14fe4fbc5542aR114) [[2]](diffhunk://#diff-aac73785d8a83d301dcdc53a5b535a072833feb46b0820027e2db7cb1ae9b142R147)
* Added `autoComplete="cc-exp"` to the expiry date input fields in both components, allowing browsers to autofill the card expiry date. [[1]](diffhunk://#diff-daf2f0bff42e60a4c77d7c68f4cce5cd347030af95752edc5dd14fe4fbc5542aR132) [[2]](diffhunk://#diff-aac73785d8a83d301dcdc53a5b535a072833feb46b0820027e2db7cb1ae9b142R195)
* Added `autoComplete="cc-csc"` to the CVC input fields in both components, enabling autofill for the card security code. [[1]](diffhunk://#diff-daf2f0bff42e60a4c77d7c68f4cce5cd347030af95752edc5dd14fe4fbc5542aR149) [[2]](diffhunk://#diff-aac73785d8a83d301dcdc53a5b535a072833feb46b0820027e2db7cb1ae9b142R212)